### PR TITLE
MCE-15993 Adds elasticsearch adapter - Adds elasticsearch query build…

### DIFF
--- a/lib/trestle/search.rb
+++ b/lib/trestle/search.rb
@@ -12,8 +12,14 @@ module Trestle
 
     autoload_under "adapters" do
       autoload :ChewyAdapter
+      autoload :ElasticsearchAdapter
       autoload :SunspotAdapter
     end
+
+    autoload_under "query_builders" do
+      autoload :ElasticsearchQueryBuilder
+    end
+
   end
 end
 

--- a/lib/trestle/search/adapters/elasticsearch_adapter.rb
+++ b/lib/trestle/search/adapters/elasticsearch_adapter.rb
@@ -1,0 +1,34 @@
+module Trestle
+  module Search
+    module ElasticsearchAdapter
+      # if your application uses WillPaginate for ElasticSearch as the default paginator
+      # trestle pagination will not be working out of the box with ElasticSearch.
+      # There is no clean way to set this as evidenced in
+      # https://github.com/elastic/elasticsearch-rails/blob/d12d812c3f52ac484cf73805ef41986dd95ba5a0/elasticsearch-model/lib/elasticsearch/model.rb
+      # This re-run resets the pagination setter when searching with trestle
+      case
+      when defined?(::Kaminari)
+        Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::Kaminari
+      when defined?(::WillPaginate)
+        Elasticsearch::Model::Response::Response.__send__ :include, Elasticsearch::Model::Response::Pagination::WillPaginate
+      end
+
+      # Pulls activerecord objects from ES query
+      def finalize_collection(query)
+        query.records
+      end
+
+      # Pulls number of records found in query
+      def count(collection)
+        collection.count
+      end
+
+      # Override the sort method which only works with activerecord
+      # Sort happens in the admin model and the Elasticsearch::Querybuilder
+      def sort(collection, field, order)
+        collection
+      end
+
+    end
+  end
+end

--- a/lib/trestle/search/query_builders/elasticsearch_query_builder.rb
+++ b/lib/trestle/search/query_builders/elasticsearch_query_builder.rb
@@ -1,0 +1,47 @@
+module Trestle
+  module Search
+    module ElasticsearchQueryBuilder
+
+      # Default query object to pass to ES queryable objects
+      # query is a string that is being searched. empty string or nil
+      # will result in all the records in the model being returned
+      # If you want fuzzy match send your query string wrapped in  *
+      # E.G. "*ist*" will return District, district, Istanbul, istanbul
+      def build_string_query(query:)
+        if query.present?
+          {
+            query: {
+              query_string: {
+                query: query
+              }
+            }
+          }
+        else
+          {
+            query: {
+              match_all: {}
+            }
+          }
+        end
+      end
+
+      # Feed a valid ES Query object and it will add the sort parameters on
+      # NOTE: Sort in ES is only available on ID unless specifically allowed on the index mapping
+      # see: https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html#fielddata-mapping-param
+      def build_sort_query(query:, params:)
+        sort = params[:sort] || :id
+        order = params[:order] || :desc
+
+        query.merge({
+          sort: [
+            sort => {
+              order: order
+            }
+          ]
+        })
+      end
+
+    end
+  end
+end
+


### PR DESCRIPTION
Sample code on how this is leveraged:

  admin.pagination_options = { per: 50 }
  adapter.include Trestle::Search::ElasticsearchAdapter
  adapter.include Trestle::Search::ElasticsearchQueryBuilder

  search do |query|
    es_query = build_string_query(query: query)
    es_query = build_sort_query(query: es_query, params: params)
    collection.search(es_query)
  end