### PR TITLE
Target main turbo-frame in search box form tag

### DIFF
--- a/app/views/trestle/search/_search.html.erb
+++ b/app/views/trestle/search/_search.html.erb
@@ -1,5 +1,5 @@
 <div class="searchbox">
-  <%= form_tag admin.path, method: :get do %>
+  <%= form_tag admin.path, method: :get, data: { turbo_frame: "main" } do %>
     <div class="input-group">
       <%= label_tag :q, icon("fas fa-search"), class: "input-group-text" %>
 


### PR DESCRIPTION
This targets the `main` turbo-frame introduced in TrestleAdmin/trestle#494 and TrestleAdmin/trestle#495 which ensures that scope counts and the header are updated when a search is performed.