### PR TITLE
Retain persistent params when performing searches

### DIFF
--- a/app/views/trestle/search/_search.html.erb
+++ b/app/views/trestle/search/_search.html.erb
@@ -1,11 +1,13 @@
 <div class="searchbox">
   <%= form_tag admin.path, method: :get, data: { turbo_frame: "main" } do %>
+    <%= serialize_persistent_params except: :q %>
+
     <div class="input-group">
       <%= label_tag :q, icon("fas fa-search"), class: "input-group-text" %>
 
       <%= search_field_tag :q, params[:q], class: "form-control", autocomplete: "off", placeholder: admin.t("search.placeholder", default: "Search") %>
 
-      <%= link_to icon("fas fa-times"), admin.path, class: "btn btn-clear-search", data: { turbo_frame: "main" } if params[:q].present? %>
+      <%= link_to icon("fas fa-times"), admin.path(nil, persistent_params.except(:q)), class: "btn btn-clear-search", data: { turbo_frame: "main" } if params[:q].present? %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Retain persistent params including current scope when searching, using the new `serialize_persistent_params` helper introduced in TrestleAdmin/trestle#493.

Fixes #13. Closes #44.