### PR TITLE
Prepare for 0.5.1 release

### DIFF
--- a/lib/trestle/search/version.rb
+++ b/lib/trestle/search/version.rb
@@ -1,5 +1,5 @@
 module Trestle
   module Search
-    VERSION = "0.5.0"
+    VERSION = "0.5.1"
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trestle-search",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Search plugin for the Trestle admin framework",
   "main": "index.scss",
   "repository": "https://github.com/TrestleAdmin/trestle-search.git",

--- a/trestle-search.gemspec
+++ b/trestle-search.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/TrestleAdmin/trestle-search"
 
-  spec.add_dependency "trestle", "~> 0.10.0"
+  spec.add_dependency "trestle", "~> 0.10.1"
 
   spec.add_development_dependency "rspec-rails"
 end


### PR DESCRIPTION
Trestle dependency has been updated to `~> 0.10.1` due to changes in #58.